### PR TITLE
Make overdubbing not stop at end of loop

### DIFF
--- a/loopor-lv2/source/loopor.cpp
+++ b/loopor-lv2/source/loopor.cpp
@@ -103,7 +103,9 @@ enum PortIndex
     /// Dub button
     LOOPER_DUB = 9,
     /// Amount of the dry signal in the output
-    LOOPER_DRY_AMOUNT = 10
+    LOOPER_DRY_AMOUNT = 10,
+    /// Select if dub ends at end of loop
+    LOOPER_CONTINUOUS_DUB = 11,
 };
 
 ///

--- a/loopor-lv2/source/loopor.cpp
+++ b/loopor-lv2/source/loopor.cpp
@@ -224,6 +224,7 @@ public:
             case LOOPER_OUTPUT2: m_output2 = (float*)data; return;
             case LOOPER_THRESHOLD: m_thresholdParameter = (const float*)data; return;
             case LOOPER_DRY_AMOUNT: m_dryAmountParameter = (const float*)data; return;
+            case LOOPER_CONINUOUS_DUB: m_continuousDubParameter = (const float*)data; return;
             default: break;
         }
 
@@ -405,6 +406,9 @@ private:
     /// Dry amount parameter
     const float* m_dryAmountParameter = NULL;
 
+    /// Continuous dub mode parameter
+    const float* m_continuousDubParameter = NULL;
+    
     /// Activate button
     MomentaryButton m_activateButton;
     /// Reset button

--- a/loopor-lv2/source/loopor.cpp
+++ b/loopor-lv2/source/loopor.cpp
@@ -383,7 +383,7 @@ public:
                     // Stop the recording only, if we did not have the threshold, yet.
                     // That allows to start recording right at the start of the loop.
                     finishRecording();
-                    if(m_nrOfDubs > 1)
+                    if(*m_continuousDubParameter && m_nrOfDubs > 1)
                     {
                         // This is the second dub, meaning we're overdubbing so don't
                         // actually stop recording dubs until the user clicks the

--- a/loopor-lv2/source/loopor.cpp
+++ b/loopor-lv2/source/loopor.cpp
@@ -376,9 +376,18 @@ public:
                 m_currentLoopIndex = 0;
 
                 if (m_state == LOOPER_STATE_RECORDING)
+                {
                     // Stop the recording only, if we did not have the threshold, yet.
                     // That allows to start recording right at the start of the loop.
                     finishRecording();
+                    if(m_nrOfDubs > 1)
+                    {
+                        // This is the second dub, meaning we're overdubbing so don't
+                        // actually stop recording dubs until the user clicks the
+                        // button again.
+                        startRecording();
+                    }
+                }
             }
         }
     }

--- a/loopor-lv2/source/loopor.lv2/loopor.ttl
+++ b/loopor-lv2/source/loopor.lv2/loopor.ttl
@@ -103,4 +103,14 @@
 			lv2:default 1.0;
 			lv2:minimum 0.0;
 			lv2:maximum 1.0;
-		] .
+		],
+		[
+			a lv2:InputPort, lv2:ControlPort;
+			lv2:index 11;
+			lv2:symbol "continudub";
+			lv2:name "Continuous Dub Mode";
+			lv2:default 0.0;
+			lv2:minimum 0.0;
+			lv2:maximum 1.0;
+			lv2:portProperty lv2:integer, lv2:toggled;
+		]  .


### PR DESCRIPTION
Most loopers don't stop once the loop end is reached allowing you to continuously overdub layer after layer without additional clicks. Some users on the forums were  asking for this feature so I thought I'd try to help out.

Bravo on writing clear, well-commented code BTW!

P.S. I just threw this together. Its not tested and I'm not sure when I'll actually have time on my mod to do any testing. :(