### PR TITLE
Added missing stdio include

### DIFF
--- a/loopor-lv2/source/loopor.cpp
+++ b/loopor-lv2/source/loopor.cpp
@@ -23,6 +23,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 // Needed for the callbacks
 #include <functional>


### PR DESCRIPTION
When I tried to build the code, the compilation failed.
The error was that the necessary header for functions like `fprintf` and such wasn't included.
Therefore, I added that include here in case someone else tries to build the project with a compiler that doesn't assume that `stdio.h` needs to be auto-inserted.